### PR TITLE
Do not perform boolean attribute logic on String literals.

### DIFF
--- a/lib/nodes/haml.js
+++ b/lib/nodes/haml.js
@@ -158,8 +158,8 @@
       while (match = findAttributes.exec(exp)) {
         key = (match[1] || match[3] || match[5]).replace(/^:/, '');
         value = match[2] || match[4] || match[6];
-        if (['false', '"false"', "'false'", '', '""', "''"].indexOf(value) === -1) {
-          if (['true', '"true"', "'true'"].indexOf(value) !== -1) {
+        if (['false', '', '""', "''"].indexOf(value) === -1) {
+          if (['true'].indexOf(value) !== -1) {
             value = "'" + key + "'";
           } else if (!value.match(/^("|').*\1$/)) {
             if (this.escapeAttributes) {

--- a/spec/suites/templates/text/attributes_boolean.haml
+++ b/spec/suites/templates/text/attributes_boolean.haml
@@ -1,8 +1,12 @@
 %input{:checked=>true}
+%input{:checked=>'true'}
 %input{:checked =>false}
+%input{:checked =>'false'}
 %input{:checked=>  0}
 %input{:checked   => ""}
 %input(checked=true)
+%input(checked='true')
 %input(checked= false)
+%input(checked= 'false')
 %input(checked=  0)
 %input(checked  = "")

--- a/spec/suites/templates/text/attributes_boolean_html5.html
+++ b/spec/suites/templates/text/attributes_boolean_html5.html
@@ -1,8 +1,12 @@
 <input checked>
+<input checked='true'>
 <input>
+<input checked='false'>
 <input checked='0'>
 <input>
 <input checked>
+<input checked='true'>
 <input>
+<input checked='false'>
 <input checked='0'>
 <input>

--- a/spec/suites/templates/text/attributes_boolean_xhtml.html
+++ b/spec/suites/templates/text/attributes_boolean_xhtml.html
@@ -1,8 +1,12 @@
 <input checked='checked' />
+<input checked='true' />
 <input />
+<input checked='false' />
 <input checked='0' />
 <input />
 <input checked='checked' />
+<input checked='true' />
 <input />
+<input checked='false' />
 <input checked='0' />
 <input />

--- a/src/nodes/haml.coffee
+++ b/src/nodes/haml.coffee
@@ -230,10 +230,10 @@ module.exports = class Haml extends Node
       value = match[2] || match[4] || match[6]
 
       # Ignore attributes some attribute values
-      if ['false', '"false"', "'false'", '', '""', "''"].indexOf(value) is -1
+      if ['false', '', '""', "''"].indexOf(value) is -1
 
         # Set key to value if the value is boolean true
-        if ['true', '"true"', "'true'"].indexOf(value) isnt -1
+        if ['true'].indexOf(value) isnt -1
           value = "'#{ key }'"
 
         # Wrap plain attributes into an interpolation, expect boolean values


### PR DESCRIPTION
Currently the boolean attribute logic is performed on String literals, which is wrong:

```
%input{ checked: 'true' }
```

will be rendered with the HTML5 format to:

```
<input checked>
```

and for the other formats to:

```
<input checked='checked' />
```

But the logic should only be performed for code attributes and not for String literals:

```
%input{ checked: true }
```

There are valid cases where you want to have 'true' as attribute value, for example within data attributes. 

There's still a difference to Ruby HAML, because the boolean attribute logic is only performed at compilation time and not render time. I decided against implementing it at render time, because it would make the compiled template more complex, larger and slower.
