### PR TITLE
Added placement option to allow for AMD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ HTML style tags are also supported:
 ### Helpers
 
 Haml Coffee supports a small subset of the Ruby Haml [helpers](http://haml-lang.com/docs/yardoc/Haml/Helpers.html). The
-provided helpers will bind the helper function to the template context, so it isn't necessary to use `=>`. 
+provided helpers will bind the helper function to the template context, so it isn't necessary to use `=>`.
 
 #### Surround
 
@@ -609,6 +609,24 @@ the newline characters to their equivalent HTML entity.
 * Default: `meta,img,link,br,hr,input,area,param,col,base`
 
 The autoclose option defines a list of tag names that should be automatically closed if they have no content.
+
+#### Module loader support
+
+* Name: `placement`
+* Type: `String`
+* Default: `global`
+
+The `placement` option defines where the template function is inserted
+upon compilation.
+
+Possible values are:
+
+* `global` <br />
+  Inserts the optionally namespaced template function into `window.HAML`.
+
+* `amd` <br />
+  Wraps the template function into a `define()` statement to allow async
+  loading via AMD.
 
 ### Custom helper function options
 

--- a/src/cli/command.coffee
+++ b/src/cli/command.coffee
@@ -49,6 +49,11 @@ argv = require('optimist')
     default   : false
     describe  : 'Extend the template scope with the context'
   )
+  .options('p',
+    alias     : 'placement',
+    default   : 'global'
+    describe  : 'Where to place the template function; one of: global, amd'
+   )
   .options('preserve',
     default   : 'pre,textarea'
     describe  : 'Set a comma separated list of HTML tags to preserve'
@@ -112,6 +117,7 @@ exports.run = ->
   namespace       = argv.n
 
   compilerOptions =
+    placement             : argv.p
     format                : argv.f
     uglify                : argv.u
     extendScope           : argv.e


### PR DESCRIPTION
Added `placement` option to rendering that when set to 'amd' places compiled function in a `define()` block to allow for AMD loading.

If there is anything else I need to do to get this merged (tests, more docs, forgot somewhere that render is called), let me know.
