### PR TITLE
Fix template names when walkdir returns absolute paths.

### DIFF
--- a/src/cli/command.coffee
+++ b/src/cli/command.coffee
@@ -1,6 +1,7 @@
 CoffeeScript  = require 'coffee-script'
 CoffeeMaker   = require './coffee-maker'
 fs            = require 'fs'
+path          = require 'path'
 walkdir       = require 'walkdir'
 
 red   = '\u001b[31m'
@@ -185,6 +186,10 @@ exports.run = ->
 
           # Loop through all Haml files and compile them
           for filename in walkdir.sync baseDir
+            # walkdir sometimes returns absolute paths
+            if filename.substring(0, 1) is '/'
+              filename = path.relative(baseDir, filename)
+
             if filename.match /([^\.]+)(\.html)?\.haml[c]?$/
 
               # Combine all files into a single output


### PR DESCRIPTION
I used the following command in Ubuntu 12.04.2 with node 0.10.12

``` bash
haml-coffee -i . -o ../some/path/templates.js
```

The template names contained absolute paths instead of relative paths. I traced that to walkdir returning absolute paths when called as `walkdir.sync('.')`. This change works around the `walkdir` oddness and gets the correct template names.
