### PR TITLE
Maintain context through includes

### DIFF
--- a/spec/suites/haml_coffee_spec.json
+++ b/spec/suites/haml_coffee_spec.json
@@ -550,6 +550,9 @@
       },
       "partials" : {
         "partials/test" : "directives/partials/test"
+      },
+      "locals" : {
+        "title": "Title For the partial."
       }
     }
   }

--- a/spec/suites/templates/directives/include.html
+++ b/spec/suites/templates/directives/include.html
@@ -1,5 +1,5 @@
 <h1>Include test</h1>
 <p>Demonstrating how includes work.</p>
-<h2>Partial</h2>
+<h2>Title For the partial.</h2>
 <p>This is a partial that can be included</p>
 <p>After text</p>

--- a/spec/suites/templates/directives/partials/test.haml
+++ b/spec/suites/templates/directives/partials/test.haml
@@ -1,2 +1,2 @@
-%h2 Partial
+%h2= @title
 %p This is a partial that can be included

--- a/src/nodes/directive.coffee
+++ b/src/nodes/directive.coffee
@@ -34,7 +34,7 @@ module.exports = class Directive extends Node
 
       context = 'this' unless context
       statement = switch @placement
-        when 'global' then "#{ @namespace }['#{ name }'].apply(#{ context })"
+        when 'global' then "#{ @namespace }['#{ name }'](#{ context })"
         when 'amd' then "require('#{ name }').apply(#{ context })"
         when 'standalone'
           if browser?.process


### PR DESCRIPTION
I ran into this while using grunt. The context for included templates was coming up was Window. I haven't had a chance to try this out in other scenarios. 
