### PR TITLE
Fix bug with silent comment nesting

### DIFF
--- a/spec/suites/templates/text/comments.haml
+++ b/spec/suites/templates/text/comments.haml
@@ -21,6 +21,9 @@
     Nor will this
      Nor will this.
 %h1 Hello
+%div
+  -# hello
+  %p this should be displayed
 %script
   BB.preloadedData = {};
   -# do NOT change the following two lines

--- a/spec/suites/templates/text/comments.html
+++ b/spec/suites/templates/text/comments.html
@@ -7,6 +7,9 @@
 <!--  %a{:href=>''} -->
 <p>foo</p>
 <h1>Hello</h1>
+<div>
+  <p>this should be displayed</p>
+</div>
 <script>
   BB.preloadedData = {};
   BB.preloadedData.about = [];

--- a/src/haml-coffee.coffee
+++ b/src/haml-coffee.coffee
@@ -275,6 +275,8 @@ module.exports = class HamlCoffee
         ws         = result[1]
         expression = result[2]
 
+        @currentIndent = ws.length
+
         # Skip empty lines
         continue if /^\s*$/.test(line)
 
@@ -287,7 +289,7 @@ module.exports = class HamlCoffee
           @lineNumber++
 
         # Ignore multiple commented lines
-        while /^-#/.test(expression) and ///^\s{#{ @previousIndent + (@tabSize || 2) }}///.test(lines[0]) and lines.length > 0
+        while /^-#/.test(expression) and ///^\s{#{ @currentIndent + (@tabSize || 2) }}///.test(lines[0]) and lines.length > 0
           lines.shift()
           @lineNumber++
 
@@ -298,8 +300,6 @@ module.exports = class HamlCoffee
           while lines[0]?.match(/(\s)+\|$/)
             expression += lines.shift().match(/^(\s*)(.*)/)[2].replace(/(\s)+\|\s*$/, '')
             @lineNumber++
-
-        @currentIndent = ws.length
 
         # Update indention levels and set the current parent
         if @indentChanged()


### PR DESCRIPTION
The parser was incorrectly killing blocks of code that were at the same
level as a silent comment if the silent comment was nested below the line
before it. Added a test case that was failing on master.
