### PR TITLE
Don't break environments without window

### DIFF
--- a/src/hamlc.coffee
+++ b/src/hamlc.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 Compiler = require './haml-coffee'
 
 if process.browser
-  CoffeeScript = window.CoffeeScript
+  CoffeeScript = window?.CoffeeScript
 else
   CoffeeScript = require 'coffee-script'
 


### PR DESCRIPTION
Encountered while upgrading old haml_coffee_assets (first appears in haml-coffee 1.13.0 - haml_coffee_assets 1.15.0)
