### PR TITLE
Made the +include directive work with standalone placement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "url": "https://github.com/netzpirat/haml-coffee/issues"
   },
   "scripts": {
-    "test": "jasmine-node --coffee spec"
+    "test": "grunt test"
   }
 }

--- a/spec/suites/haml_coffee_spec.json
+++ b/spec/suites/haml_coffee_spec.json
@@ -190,7 +190,7 @@
         "format" : "html5"
       }
     },
-    
+
     "class concatenation" : {
       "haml_template" : "coffee/class",
       "html_template" : "coffee/class"
@@ -542,7 +542,7 @@
   },
 
   "directives" : {
-    "include" : {
+    "include global" : {
       "haml_template" : "directives/include",
       "html_template" : "directives/include",
       "config": {
@@ -550,6 +550,16 @@
       },
       "partials" : {
         "partials/test" : "directives/partials/test"
+      },
+      "locals" : {
+        "title": "Title For the partial."
+      }
+    },
+    "include standalone" : {
+      "haml_template" : "directives/include",
+      "html_template" : "directives/include",
+      "config": {
+        "placement": "standalone"
       },
       "locals" : {
         "title": "Title For the partial."

--- a/src/haml-coffee.coffee
+++ b/src/haml-coffee.coffee
@@ -52,6 +52,7 @@ module.exports = class HamlCoffee
     @options.hyphenateDataAttrs ?= true
     @options.preserveTags       ?= 'pre,textarea'
     @options.selfCloseTags      ?= 'meta,img,link,br,hr,input,area,param,col,base'
+    @options.extension          ?= 'haml'
 
     if @options.placement is 'global'
       @options.name      ?= 'test'
@@ -168,6 +169,7 @@ module.exports = class HamlCoffee
       placement          : override.placement          || @options.placement
       namespace          : override.namespace          || @options.namespace
       name               : override.name               || @options.name
+      compilerOptions    : @options
     }
 
   # Get the matching node type for the given expression. This

--- a/src/hamlc.coffee
+++ b/src/hamlc.coffee
@@ -1,4 +1,5 @@
-fs = require 'fs'
+fs   = require 'fs'
+path = require 'path'
 
 Compiler = require './haml-coffee'
 
@@ -105,7 +106,8 @@ module.exports =
 
       else
         options.filename = filename
-        source = fs.readFileSync(filename, 'utf8')
+        options.pwd      = path.dirname(filename)
+        source           = fs.readFileSync(filename, 'utf8')
 
         if options.cache
           __expressCache[filename] = module.exports.compile(source, options)

--- a/src/nodes/directive.coffee
+++ b/src/nodes/directive.coffee
@@ -44,16 +44,21 @@ module.exports = class Directive extends Node
             # we need to compile the referenced template and attach it as a
             # precompiled (standalone) template here.
 
+            templatePath = path.join(
+              @options.compilerOptions.pwd,
+              "#{ name }.#{ @options.compilerOptions.extension }"
+            )
+
             # Read the source.
             try
-              source = fs.readFileSync(name).toString()
+              source = fs.readFileSync(templatePath).toString()
             catch error
               console.error "  Error opening file: %s", error
               console.error error
 
             # Compile and build the source function.
             Compiler = require '../haml-coffee'
-            compiler = new Compiler(@options)
+            compiler = new Compiler(@options.compilerOptions)
             compiler.parse source
             code = CoffeeScript.compile(compiler.precompile(), bare: true)
             statement = "`(function(){#{code}}).apply(#{context})`"

--- a/src/nodes/node.coffee
+++ b/src/nodes/node.coffee
@@ -32,8 +32,8 @@ module.exports = class Node
   # @option options [Boolean] escapeHtml whether to escape the rendered HTML or not
   # @option options [String] format the template format, either `xhtml`, `html4` or `html5`
   #
-  constructor: (@expression = '', options = {}) ->
-    @parentNode = options.parentNode
+  constructor: (@expression = '', @options = {}) ->
+    @parentNode = @options.parentNode
     @children   = []
 
     @opener = @closer = null
@@ -42,7 +42,7 @@ module.exports = class Node
     @silent   = false
 
     # Preserve whitespace on all children
-    @preserveTags = options.preserveTags.split(',')
+    @preserveTags = @options.preserveTags.split(',')
     @preserve = false
 
     @wsRemoval = {
@@ -50,20 +50,20 @@ module.exports = class Node
       inside: false
     }
 
-    @escapeHtml         = options.escapeHtml
-    @escapeAttributes   = options.escapeAttributes
-    @cleanValue         = options.cleanValue
-    @format             = options.format
-    @hyphenateDataAttrs = options.hyphenateDataAttrs
-    @selfCloseTags      = options.selfCloseTags.split(',')
-    @uglify             = options.uglify
+    @escapeHtml         = @options.escapeHtml
+    @escapeAttributes   = @options.escapeAttributes
+    @cleanValue         = @options.cleanValue
+    @format             = @options.format
+    @hyphenateDataAttrs = @options.hyphenateDataAttrs
+    @selfCloseTags      = @options.selfCloseTags.split(',')
+    @uglify             = @options.uglify
 
-    @codeBlockLevel     = options.codeBlockLevel
-    @blockLevel         = options.blockLevel
+    @codeBlockLevel     = @options.codeBlockLevel
+    @blockLevel         = @options.blockLevel
 
-    @placement          = options.placement
-    @namespace          = options.namespace
-    @name               = options.name
+    @placement          = @options.placement
+    @namespace          = @options.namespace
+    @name               = @options.name
 
   # Add a child node.
   #


### PR DESCRIPTION
The +include directive was working for global placement but not for standalone placement.  The only way you could use +include with standalone was to specify an absolute path to the template (which isn't so useful). This commit makes the file loading relative to the template initiating the directive.  I also added a test.
