### PR TITLE
Bug: '@' is not compiled for '+include' context

### DIFF
--- a/spec/suites/templates/directives/include.haml
+++ b/spec/suites/templates/directives/include.haml
@@ -1,4 +1,6 @@
 %h1 Include test
 %p Demonstrating how includes work.
-+include 'partials/test'
++include 'partials/test', {title: @title, subtitle: @title.replace(/Title/, 'Subtitle')}
++include 'partials/test', {title: "@title", subtitle: "@subtitle"}
++include 'partials/test', @
 %p After text

--- a/spec/suites/templates/directives/include.html
+++ b/spec/suites/templates/directives/include.html
@@ -2,4 +2,8 @@
 <p>Demonstrating how includes work.</p>
 <h2>Title For the partial.</h2>
 <p>This is a partial that can be included</p>
+<h2>@title</h2>
+<p>This is a partial that can be included</p>
+<h2>Title For the partial.</h2>
+<p>This is a partial that can be included</p>
 <p>After text</p>

--- a/src/nodes/directive.coffee
+++ b/src/nodes/directive.coffee
@@ -56,6 +56,7 @@ module.exports = class Directive extends Node
             compiler = new Compiler(@options)
             compiler.parse source
             code = CoffeeScript.compile(compiler.precompile(), bare: true)
+            context = CoffeeScript.compile(context, bare: true).replace(/;\s*$/, '')
             statement = "`(function(){#{code}}).apply(#{context})`"
 
         else


### PR DESCRIPTION
When compiling the following haml, the '@' will not be handled. I made a small fix to replace '@' with 'this.'.
```hamlc
+include 'partials/test', {title: @title, subtitle: @title.replace(/Title/, 'Subtitle')}
```