### PR TITLE
Update deprecated coffee-script package to coffeescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "haml-coffee": "./bin/haml-coffee"
   },
   "dependencies": {
-    "coffee-script": ">= 1.1.3",
+    "coffeescript": ">= 1.1.3",
     "walkdir": "~0.0.7",
     "optimist": "~0.6.0"
   },


### PR DESCRIPTION
The `coffee-script` package has been deprecated in favor for `coffeescript` where the hyphen is dropped. The version that is required is supported in the dropped hyphen version, https://www.npmjs.com/package/coffeescript/v/1.1.3.

Just for context, this is the log I'm seeing when installing dependencies:
![Image 2019-12-11 10-03-28](https://user-images.githubusercontent.com/1127677/70632929-aeb51400-1bfd-11ea-8234-b175ff9ca294.png)