### PR TITLE
test node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "6"
+  - 6
+  - 12
 branches:
   only:
     - master


### PR DESCRIPTION
We are are updating our build tools to use node 12  wanted to know if haml-coffee works on node 12, this pr is for testing that using travis CI

- [x] Add an additional node version in the travis jobs
- ~Blocked by enabling travis~ (looks like it is no longer enabled) 

https://travis-ci.org/github/netzpirat/haml-coffee

<img width="738" alt="Screen Shot 2020-07-17 at 4 23 32 PM" src="https://user-images.githubusercontent.com/196199/87827955-efd36d80-c849-11ea-8ab3-b850dc60671e.png">

- [x] Confirmed working by using my fork https://travis-ci.org/github/cesine/haml-coffee/builds/709317346

<img width="847" alt="Screen Shot 2020-07-17 at 4 31 11 PM" src="https://user-images.githubusercontent.com/196199/87828447-f2829280-c84a-11ea-9354-a58f56b5973c.png">
